### PR TITLE
Update wait time for cinematic generation checks from 60->40s

### DIFF
--- a/src/tools/asset-generate/common/wait-tool.ts
+++ b/src/tools/asset-generate/common/wait-tool.ts
@@ -12,7 +12,7 @@ export class AssetWaitTool implements Tool {
   description = `A universal tool for waiting a specified amount of time.
 
 Common use cases:
-- Wait between cinematic generation status checks (recommended: 60 seconds)
+- Wait between cinematic generation status checks (recommended: 40 seconds)
 - Wait between skybox generation status checks (recommended: 10-20 seconds)
 - Wait between audio generation status checks (recommended: 5-10 seconds)
 


### PR DESCRIPTION
## Description of Changes

Update recommended wait time for cinematic generation checks from 60 seconds to 40 seconds in AssetWaitTool.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other changes

## Does this change include dependency updates?

- [ ] Yes
- [ ] No

## Testing

Please describe how you tested these changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependent changes have been merged and published
