### PR TITLE
Force duration to integer, for duration on sfx_generate

### DIFF
--- a/src/tools/asset-generate/audio/sfx/sfx-generation.ts
+++ b/src/tools/asset-generate/audio/sfx/sfx-generation.ts
@@ -70,7 +70,7 @@ Use this tool when you need to:
       },
       duration: {
         type: 'number',
-        description: 'Duration of the sound effect in seconds (1-30)',
+        description: 'Duration of the sound effect in seconds (1-30, integer values only)',
         default: DEFAULT_AUDIO_DURATION,
       },
     },
@@ -78,9 +78,13 @@ Use this tool when you need to:
   };
 
   protected sanitizeAudioArgs(args: Record<string, any>): Record<string, any> {
+    const duration = args.duration || DEFAULT_AUDIO_DURATION;
+    if (!Number.isInteger(duration) || duration < 1 || duration > 30) {
+      throw new Error('Duration must be an integer between 1 and 30 seconds.');
+    }
     return {
       prompt: args.prompt,
-      duration: args.duration || DEFAULT_AUDIO_DURATION,
+      duration: duration,
     };
   }
 


### PR DESCRIPTION
## Description of Changes

As title suggest, this PR adds validation check and mention about `duration` for `sfx_generate` due to fal.ai spec. (see also: https://fal.ai/api/openapi/queue/openapi.json?endpoint_id=cassetteai/sound-effects-generator) 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other changes

## Does this change include dependency updates?

- [ ] Yes
- [x] No

## Testing

Please describe how you tested these changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All dependent changes have been merged and published
