### PR TITLE
Fix bug in code example formatting

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { logger } from '../utils/logging.js';
 import { V8User } from '../types/v8user.js';
 
-/**`
+/**
  * Validates an access token
  * In production, this should call an external authentication service
  */

--- a/src/tools/vector-search/code-examples.ts
+++ b/src/tools/vector-search/code-examples.ts
@@ -223,7 +223,7 @@ export class CodeExampleSearchTool implements Tool {
 
       formatted += '**Files:**\n';
       example.files.forEach((file) => {
-        formatted += `- \`${results[file].content}\`\n`;
+        formatted += `- \`${file}\`\n`;
       });
 
       formatted += '\n';


### PR DESCRIPTION
## Summary
- output filenames instead of file contents in search results
- remove stray backtick in auth middleware comment

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: Cannot find module 'jest')*