### PR TITLE
Use Veo3 for prompt-only cinematics

### DIFF
--- a/src/tools/asset-generate/common/asset-generator.ts
+++ b/src/tools/asset-generate/common/asset-generator.ts
@@ -16,6 +16,7 @@ export abstract class AssetGeneratorBase implements Tool {
     const { progressCallback } = context;
     try {
       // Common preprocessing
+      args = this.sanitizeToolArgs(args);
       const apiEndpoint = this.getApiEndpoint(args);
 
       // Initial progress reporting
@@ -49,8 +50,6 @@ export abstract class AssetGeneratorBase implements Tool {
           throw new Error(`Credit consumption failed: ${creditError instanceof Error ? creditError.message : String(creditError)}`);
         }
       }
-
-      args = this.sanitizeToolArgs(args);
 
       // Call the asset generation method of child class
       const result = await this.generateAsset(args, apiEndpoint, context);


### PR DESCRIPTION
## Summary
- use Veo3 when no reference images are supplied
- integrate Veo3 prompt guidelines in the cinematic tool description
- remove the extra documentation file and README reference

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68430de432e08326ab58b0c819159ae4